### PR TITLE
Fixes to ensure gradle plugin works correctly with service account JSON credentials

### DIFF
--- a/buildartifacts-auth-common/src/main/java/com/google/cloud/buildartifacts/auth/DefaultCredentialProvider.java
+++ b/buildartifacts-auth-common/src/main/java/com/google/cloud/buildartifacts/auth/DefaultCredentialProvider.java
@@ -24,6 +24,9 @@ import java.io.IOException;
 // Credentials if that fails.
 public class DefaultCredentialProvider implements CredentialProvider {
 
+  private static String[] SCOPES = {"https://www.googleapis.com/auth/cloud-platform",
+      "https://www.googleapis.com/auth/cloud-platform.read-only"};
+
   @Override
   public Credentials getCredential() throws IOException {
     Credentials credentials;
@@ -31,6 +34,6 @@ public class DefaultCredentialProvider implements CredentialProvider {
     if (credentials != null) {
       return credentials;
     }
-    return GoogleCredentials.getApplicationDefault();
+    return GoogleCredentials.getApplicationDefault().createScoped(SCOPES);
   }
 }

--- a/buildartifacts-auth-common/src/main/java/com/google/cloud/buildartifacts/auth/GcloudCredentials.java
+++ b/buildartifacts-auth-common/src/main/java/com/google/cloud/buildartifacts/auth/GcloudCredentials.java
@@ -53,7 +53,7 @@ public class GcloudCredentials extends GoogleCredentials {
     try {
       return new GcloudCredentials(getGcloudAccessToken());
     } catch (IOException e) {
-      LOGGER.info("Failed to get credentials from gcloud: " + e.getMessage());
+      LOGGER.fine("Failed to get credentials from gcloud: " + e.getMessage());
       return null;
     }
   }

--- a/buildartifacts-gradle-plugin/src/main/java/com/google/cloud/buildartifacts/gradle/plugin/BuildArtifactsGradlePlugin.java
+++ b/buildartifacts-gradle-plugin/src/main/java/com/google/cloud/buildartifacts/gradle/plugin/BuildArtifactsGradlePlugin.java
@@ -98,12 +98,13 @@ public class BuildArtifactsGradlePlugin implements Plugin<Project> {
           if (cbaRepo.getConfiguredCredentials() == null) {
             try {
               GoogleCredentials credentials = (GoogleCredentials)credentialProvider.getCredential();
+              credentials.refreshIfExpired();
               AccessToken accessToken = credentials.getAccessToken();
               String token = accessToken.getTokenValue();
               BuildArtifactsPasswordCredentials crd = new BuildArtifactsPasswordCredentials("oauth2accesstoken", token);
               cbaRepo.setConfiguredCredentials((Credentials)crd);
             } catch (IOException e) {
-              throw new UncheckedIOException("Failed to get access token from gcloud", e);
+              throw new UncheckedIOException("Failed to get access token from gcloud or Application Default Credentials", e);
             }
           }
         }


### PR DESCRIPTION
* Refresh the credential if needed. This is necessary because the accessToken will initially be empty.
* Initialize the credential with the cloud-platform scopes when using a credential that supports it.

Fixes #12 