### PR TITLE
fix: add rate limiting to GcloudCredentials token refresh

### DIFF
--- a/artifactregistry-auth-common/src/main/java/com/google/cloud/artifactregistry/auth/DefaultCredentialProvider.java
+++ b/artifactregistry-auth-common/src/main/java/com/google/cloud/artifactregistry/auth/DefaultCredentialProvider.java
@@ -40,6 +40,9 @@ public final class DefaultCredentialProvider implements CredentialProvider {
     return defaultInstance;
   }
 
+  // Rate limiting for refresh calls. Note: This only guards calls through getCredential().
+  // HttpCredentialsAdapter bypasses this by calling refreshIfExpired() directly on credentials.
+  // GcloudCredentials has its own rate limiting to handle that case.
   public static long LAST_REFRESH_TIME_MS = 0;
   public static final long REFESH_INTERVAL_MS = Duration.ofSeconds(10).toMillis();
 

--- a/artifactregistry-auth-common/src/main/java/com/google/cloud/artifactregistry/auth/GcloudCredentials.java
+++ b/artifactregistry-auth-common/src/main/java/com/google/cloud/artifactregistry/auth/GcloudCredentials.java
@@ -41,6 +41,23 @@ public class GcloudCredentials extends GoogleCredentials {
   private static final String KEY_ACCESS_TOKEN = "access_token";
   private static final String KEY_TOKEN_EXPIRY = "token_expiry";
 
+  // Rate limiting for refresh calls to avoid excessive gcloud invocations.
+  // This is necessary because HttpCredentialsAdapter calls refreshIfExpired() on every
+  // HTTP request, bypassing the rate limiting in DefaultCredentialProvider.
+  // With per-lookup wagon instantiation, builds with many artifacts could trigger
+  // a ton of gcloud CLI calls without this protection.
+  static final long MIN_REFRESH_INTERVAL_MS = Duration.ofSeconds(15).toMillis();
+  static final long MIN_TOKEN_LIFETIME_MS = Duration.ofSeconds(60).toMillis();
+  private static final Object refreshLock = new Object();
+  private static long lastRefreshTimeMs = 0;
+
+  // Visible for testing
+  static void resetRateLimitingState() {
+    synchronized (refreshLock) {
+      lastRefreshTimeMs = 0;
+    }
+  }
+
   private final CommandExecutor commandExecutor;
 
 
@@ -67,10 +84,34 @@ public class GcloudCredentials extends GoogleCredentials {
   }
 
   // This is called if the token expires, from the calls to refreshIfExpired()
+  // Rate limited to avoid excessive gcloud invocations during builds with many artifacts.
   @Override
   public AccessToken refreshAccessToken() throws IOException {
-    LOGGER.info("Refreshing gcloud credentials...");
-    return validateAccessToken(getGcloudAccessToken(this.commandExecutor));
+    synchronized (refreshLock) {
+      long now = Instant.now().toEpochMilli();
+
+      // Check if we refreshed recently
+      if ((now - lastRefreshTimeMs) < MIN_REFRESH_INTERVAL_MS) {
+        AccessToken currentToken = getAccessToken();
+        if (currentToken != null) {
+          // Only return cached token if it has enough lifetime remaining
+          Date expiry = currentToken.getExpirationTime();
+          if (expiry != null) {
+            long timeUntilExpiry = expiry.getTime() - now;
+            if (timeUntilExpiry > MIN_TOKEN_LIFETIME_MS) {
+              LOGGER.debug("Skipping refresh, token still valid for {}ms", timeUntilExpiry);
+              return currentToken;
+            }
+          }
+          // Token has no expiry or is expiring very soon, allow refresh even within rate limit
+        }
+      }
+
+      LOGGER.info("Refreshing gcloud credentials...");
+      AccessToken newToken = validateAccessToken(getGcloudAccessToken(this.commandExecutor));
+      lastRefreshTimeMs = now;
+      return newToken;
+    }
   }
 
   // Checks that the token is valid, throws IOException if it is expired.
@@ -80,7 +121,7 @@ public class GcloudCredentials extends GoogleCredentials {
   // login.
   private static AccessToken validateAccessToken(AccessToken token) throws IOException {
       Date expiry = token.getExpirationTime();
-      if (expiry.before(new Date())) {
+      if (expiry != null && expiry.before(new Date())) {
         throw new IOException("AccessToken is expired - maybe run `gcloud auth login`");
       }
       return token;

--- a/artifactregistry-auth-common/src/test/java/com/google/cloud/artifactregistry/auth/GcloudCredentialsTest.java
+++ b/artifactregistry-auth-common/src/test/java/com/google/cloud/artifactregistry/auth/GcloudCredentialsTest.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.artifactregistry.auth;
+
+import com.google.auth.oauth2.AccessToken;
+import java.io.IOException;
+import java.time.Instant;
+import java.util.Date;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class GcloudCredentialsTest {
+
+  @Before
+  public void setUp() {
+    GcloudCredentials.resetRateLimitingState();
+  }
+
+  @After
+  public void tearDown() {
+    GcloudCredentials.resetRateLimitingState();
+  }
+
+  @Test
+  public void testRefreshAccessTokenRateLimiting() throws Exception {
+    AtomicInteger gcloudCallCount = new AtomicInteger(0);
+    // Use a short expiry to trigger refresh, but not so short that MIN_TOKEN_LIFETIME_MS kicks in
+    Date shortExpiry = Date.from(Instant.now().plusSeconds(30));
+    Date longExpiry = Date.from(Instant.now().plusSeconds(600));
+
+    GcloudCredentials credentials = new GcloudCredentials(
+        new AccessToken("initial-token", shortExpiry),
+        new CountingCommandExecutor(gcloudCallCount, longExpiry)
+    );
+
+    // First refresh should call gcloud
+    credentials.refresh();
+    Assert.assertEquals(1, gcloudCallCount.get());
+    Assert.assertEquals("token-1", credentials.getAccessToken().getTokenValue());
+
+    // Subsequent refreshes within the rate limit window should not call gcloud again
+    // because the token now has longExpiry (> MIN_TOKEN_LIFETIME_MS)
+    credentials.refresh();
+    Assert.assertEquals(1, gcloudCallCount.get()); // Still 1, no new gcloud call
+
+    credentials.refresh();
+    Assert.assertEquals(1, gcloudCallCount.get()); // Still 1
+  }
+
+  @Test
+  public void testRefreshAccessTokenAllowsRefreshWhenTokenExpiringSoon() throws Exception {
+    AtomicInteger gcloudCallCount = new AtomicInteger(0);
+    // Token expires in 30 seconds (less than MIN_TOKEN_LIFETIME_MS of 60 seconds)
+    Date shortExpiry = Date.from(Instant.now().plusSeconds(30));
+
+    // Create a command executor that always returns tokens with short expiry
+    // This simulates the case where gcloud keeps returning near-expiry tokens
+    GcloudCredentials credentials = new GcloudCredentials(
+        new AccessToken("initial-token", shortExpiry),
+        new CountingCommandExecutor(gcloudCallCount, shortExpiry)
+    );
+
+    // First refresh
+    credentials.refresh();
+    Assert.assertEquals(1, gcloudCallCount.get());
+
+    // Even within rate limit window, should refresh because token is expiring soon
+    // (less than MIN_TOKEN_LIFETIME_MS of 60 seconds)
+    credentials.refresh();
+    Assert.assertEquals(2, gcloudCallCount.get()); // Should have called gcloud again
+  }
+
+  @Test
+  public void testRefreshAccessTokenValidatesToken() throws Exception {
+    AtomicInteger gcloudCallCount = new AtomicInteger(0);
+    // gcloud returns an expired token
+    Date expiredDate = Date.from(Instant.now().minusSeconds(60));
+
+    GcloudCredentials credentials = new GcloudCredentials(
+        new AccessToken("initial-token", Date.from(Instant.now().plusSeconds(600))),
+        new CountingCommandExecutor(gcloudCallCount, expiredDate)
+    );
+
+    try {
+      credentials.refresh();
+      Assert.fail("Expected IOException for expired token");
+    } catch (IOException e) {
+      Assert.assertTrue(e.getMessage().contains("expired"));
+    }
+  }
+
+  private static class CountingCommandExecutor implements CommandExecutor {
+    private final AtomicInteger callCount;
+    private final Date tokenExpiry;
+
+    CountingCommandExecutor(AtomicInteger callCount, Date tokenExpiry) {
+      this.callCount = callCount;
+      this.tokenExpiry = tokenExpiry;
+    }
+
+    @Override
+    public CommandExecutorResult executeCommand(String command, String... args) throws IOException {
+      int count = callCount.incrementAndGet();
+      // Return a valid gcloud config-helper JSON response
+      String jsonResponse = String.format(
+          "{\"credential\":{\"access_token\":\"token-%d\",\"token_expiry\":\"%s\"}}",
+          count,
+          formatDate(tokenExpiry)
+      );
+      return new CommandExecutorResult(0, jsonResponse, "");
+    }
+
+    private String formatDate(Date date) {
+      java.text.SimpleDateFormat df = new java.text.SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
+      df.setTimeZone(java.util.TimeZone.getTimeZone("UTC"));
+      return df.format(date);
+    }
+  }
+}

--- a/artifactregistry-gradle-plugin/src/main/java/com/google/cloud/artifactregistry/gradle/plugin/ArtifactRegistryGradlePlugin.java
+++ b/artifactregistry-gradle-plugin/src/main/java/com/google/cloud/artifactregistry/gradle/plugin/ArtifactRegistryGradlePlugin.java
@@ -105,7 +105,6 @@ public class ArtifactRegistryGradlePlugin implements Plugin<Object> {
       CommandExecutor commandExecutor = new ProviderFactoryCommandExecutor(providerFactory);
 
       GoogleCredentials credentials = (GoogleCredentials)credentialProvider.getCredential(commandExecutor);
-      credentials.refreshIfExpired();
       AccessToken accessToken = credentials.getAccessToken();
       String token = accessToken.getTokenValue();
       crd = new ArtifactRegistryPasswordCredentials("oauth2accesstoken", token, commandExecutor);


### PR DESCRIPTION
Prevents excessive gcloud CLI invocations during builds with many deps.
The HttpCredentialsAdapter calls refreshIfExpired() on every HTTP request,
which can trigger a ton of gcloud commands per build when the token is near
expiry.

Changes:
- Add 15-second rate limiting to GcloudCredentials.refreshAccessToken()
- Allow refresh bypass when token has less than 60 seconds lifetime
- Remove redundant refreshIfExpired() call in ArtifactRegistryGradlePlugin
- Add unit tests for rate limiting behavior